### PR TITLE
Fix undefined property warnings for requires and requires_php

### DIFF
--- a/src/Updaters/Plugin.php
+++ b/src/Updaters/Plugin.php
@@ -275,8 +275,8 @@ class Plugin extends Updater {
 		$limited_data->banners      = $this->convert_object_to_array( $version_info->banners );
 		$limited_data->new_version  = $version_info->new_version ?? '';
 		$limited_data->tested       = $version_info->tested ?? '';
-		$limited_data->requires     = $version_info->requires;
-		$limited_data->requires_php = $version_info->requires_php;
+		$limited_data->requires     = $version_info->requires ?? '';
+		$limited_data->requires_php = $version_info->requires_php ?? '';
 
 		return $limited_data;
 	}


### PR DESCRIPTION
## Summary
- Apply `??` fallbacks in `Plugin::get_limited_data()` when reading `$version_info->requires` and `$version_info->requires_php`
- Cached payloads predating the defaults added in `get_repo_api_data()` triggered PHP 8.2+ "Undefined property" warnings because `get_repo_api_data()` returns cached data before reaching the default-assignment block

Fixes #66

## Test plan
- [ ] Load a site where the plugin's version info is already cached without `requires` / `requires_php` and confirm no warnings appear in the error log
- [ ] Flush the cache, let it repopulate, and confirm updates still surface correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)