### PR TITLE
Jitter and harden weekly license check cron (#70)

### DIFF
--- a/src/Handlers/Handler.php
+++ b/src/Handlers/Handler.php
@@ -154,10 +154,27 @@ abstract class Handler {
 		$api          = new \EasyDigitalDownloads\Updater\Requests\API( $this->args['api_url'] );
 		$license_data = $api->make_request( $api_params );
 		if ( empty( $license_data->success ) ) {
+			$this->reschedule_after_failure();
 			return;
 		}
 
 		$this->license->save( $license_data );
+	}
+
+	/**
+	 * Reschedules the next license check ~1 hour out after a failed request,
+	 * so we don't wait a full week to retry when the store was briefly down.
+	 *
+	 * @since 1.0.4
+	 * @return void
+	 */
+	private function reschedule_after_failure() {
+		$hook = 'edd_sl_sdk_weekly_license_check_' . $this->args['slug'];
+		$next = wp_next_scheduled( $hook );
+		if ( $next ) {
+			wp_unschedule_event( $next, 'weekly', $hook );
+		}
+		wp_schedule_event( time() + HOUR_IN_SECONDS + wp_rand( 0, 15 * MINUTE_IN_SECONDS ), 'weekly', $hook );
 	}
 
 	/**
@@ -192,7 +209,9 @@ abstract class Handler {
 		add_action( 'wp_ajax_edd_sl_sdk_update_tracking_' . $slug, array( $this->license, 'ajax_update_tracking' ) );
 		if ( ! empty( $this->args['weekly_check'] ) ) {
 			if ( ! wp_next_scheduled( 'edd_sl_sdk_weekly_license_check_' . $slug ) ) {
-				wp_schedule_event( time(), 'weekly', 'edd_sl_sdk_weekly_license_check_' . $slug );
+				// Jitter the first run within a 24h window so many sites/plugins activating
+				// on the same day do not all hit the EDD store at the same hour every week.
+				wp_schedule_event( time() + wp_rand( 0, DAY_IN_SECONDS ), 'weekly', 'edd_sl_sdk_weekly_license_check_' . $slug );
 			}
 			add_action( 'edd_sl_sdk_weekly_license_check_' . $slug, array( $this, 'weekly_license_check' ) );
 		}

--- a/src/Handlers/Handler.php
+++ b/src/Handlers/Handler.php
@@ -170,10 +170,7 @@ abstract class Handler {
 	 */
 	private function reschedule_after_failure() {
 		$hook = 'edd_sl_sdk_weekly_license_check_' . $this->args['slug'];
-		$next = wp_next_scheduled( $hook );
-		if ( $next ) {
-			wp_unschedule_event( $next, 'weekly', $hook );
-		}
+		wp_clear_scheduled_hook( $hook );
 		wp_schedule_event( time() + HOUR_IN_SECONDS + wp_rand( 0, 15 * MINUTE_IN_SECONDS ), 'weekly', $hook );
 	}
 


### PR DESCRIPTION
Spread the weekly license check across a 24h window and back off ~1h after a failed request, so many sites activating on the same day do not all hit the EDD store at the same hour and so a transient store outage does not force a full week wait before re-syncing.