### PR TITLE
Buffer early Manage License clicks until the SDK script is ready

### DIFF
--- a/src/Handlers/Plugin.php
+++ b/src/Handlers/Plugin.php
@@ -31,6 +31,7 @@ class Plugin extends Handler {
 	protected function add_listeners(): void {
 		$plugin_basename = plugin_basename( $this->args['file'] );
 		add_filter( "plugin_action_links_{$plugin_basename}", array( $this, 'plugin_links' ), 100, 3 );
+		add_action( 'admin_print_scripts-plugins.php', array( $this, 'print_early_trigger_buffer' ) );
 	}
 
 		/**
@@ -88,6 +89,58 @@ class Plugin extends Handler {
 		add_action( 'admin_footer', array( $this, 'license_modal' ) );
 
 		return $actions;
+	}
+
+	/**
+	 * Buffers clicks on the license trigger until the SDK script is ready.
+	 *
+	 * The "Manage License" trigger is rendered with the plugins list, but its
+	 * click listener is only bound once the SDK footer script has executed.
+	 * On plugin-heavy sites that leaves a multi-second window in which clicks
+	 * are silently ignored. This tiny head script catches those early clicks,
+	 * shows the core spinner state as feedback, and re-dispatches the click
+	 * once the SDK is ready.
+	 *
+	 * @since 1.0.4
+	 * @return void
+	 */
+	public function print_early_trigger_buffer() {
+		static $did_run;
+		if ( $did_run ) {
+			return;
+		}
+		$did_run = true;
+
+		$script = <<<'JS'
+( function() {
+	var pending = false;
+	document.addEventListener( 'click', function( event ) {
+		var trigger = event.target && event.target.closest ? event.target.closest( '.edd-sdk__notice__trigger' ) : null;
+		if ( ! trigger || pending || document.querySelector( '.edd-sdk__notice__overlay' ) ) {
+			return;
+		}
+		event.preventDefault();
+		event.stopImmediatePropagation();
+		pending = true;
+		trigger.classList.add( 'updating-message' );
+		var started = Date.now();
+		var timer = window.setInterval( function() {
+			var ready = document.querySelector( '.edd-sdk__notice__overlay' );
+			if ( ! ready && Date.now() - started < 15000 ) {
+				return;
+			}
+			window.clearInterval( timer );
+			trigger.classList.remove( 'updating-message' );
+			pending = false;
+			if ( ready ) {
+				trigger.click();
+			}
+		}, 200 );
+	}, true );
+} )();
+JS;
+
+		wp_print_inline_script_tag( $script );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Print a tiny dependency-free inline script in the head of `plugins.php` (via `admin_print_scripts-plugins.php`) that catches clicks on `.edd-sdk__notice__trigger` while the SDK wrapper (`.edd-sdk__notice__overlay`) does not exist yet
- The trigger is rendered with the plugins list, but its click listener is only bound once the SDK footer script has executed — on plugin-heavy sites that leaves a multi-second window (measured 3–4 s on a warm cache with ~215 admin scripts) in which clicks are silently ignored
- Early clicks now get the core `updating-message` spinner state as feedback and are re-dispatched once the SDK is ready (15 s timeout); after SDK init the buffer is a no-op and clicks are handled by the SDK directly
- Static guard mirrors `license_modal()` so the script prints once even when several SDK-registered plugins are active

Fixes #75

## Test plan
- [ ] On a plugin-heavy site (or with devtools CPU/network throttling) open `wp-admin/plugins.php` and click "Manage License" while scripts are still loading: the button shows the spinner and the license modal opens as soon as the SDK is ready
- [ ] Click "Manage License" after the page has fully loaded: the modal opens directly, the buffer stays inactive
- [ ] Keyless plugins / pages without SDK triggers: no behavior change

An equivalent click buffer shipped today as a plugin-side workaround and was verified end-to-end in a production admin (synchronous intercept + spinner, blocked SDK handler while parked, automatic re-dispatch and modal open once ready).